### PR TITLE
Doc

### DIFF
--- a/bin/linter.ml
+++ b/bin/linter.ml
@@ -2,25 +2,11 @@ open Canonical
 open Traverse
 
 let store : Hint.hint list ref = ref []
-
-
-let line_length_lint : string -> unit = fun file ->
-  let chan = open_in file in
-  let lref : int ref = ref 1 in
-  try
-    while true; do
-      let line = input_line chan in
-      (if (String.length line > 80) then store := Hint.line_hint file !lref line :: !store;);
-      incr lref
-    done; ()
-  with End_of_file ->
-    close_in chan; ()
         
 (* Build a list of hints using the patterns *)
 
 let lint : (string * Parsetree.structure) list -> unit =
   List.iter (fun (file, ast) ->
-      line_length_lint file;
       Iter.make_linterator store file |>
       Iter.apply_iterator ast
     )

--- a/lib/arthur/arthur_parse.ml
+++ b/lib/arthur/arthur_parse.ml
@@ -132,7 +132,9 @@ let rec json_to_arthur : Yojson.Basic.t option -> arthur = fun tl ->
     and+ toLint = files raw in
     return (Arthur (toLint, glob, locals)) <?> return default
   in
-  Option.get parse_in
+  match parse_in with
+  | None -> default
+  | Some v -> v
 
 and files : Yojson.Basic.t -> files option = fun j ->
   let open OptInst in

--- a/lib/canonical/patternctxt.ml
+++ b/lib/canonical/patternctxt.ml
@@ -1,16 +1,57 @@
 open Warnloc
 
+type _ gt =
+  | Int : {e: int; f: int} -> int gt
+  | Bool : {e: int; f: bool} -> bool gt
+  | Str : {e: int; f: string} -> string gt
+
+let f : string gt -> string = fun s ->
+  match s with
+  | Str s -> s.f
+
+
+
+
+
 type _ pctxt =
+  (* Expression constructor *)
   | E : { location: warn_loc;
           source: string;
           pattern: Parsetree.expression_desc
         } -> Parsetree.expression_desc pctxt
-
+  (*  Top Level let constructor *)
   | P : {location: warn_loc;
          source: string;
          pattern: Parsetree.structure_item_desc
         } -> Parsetree.structure_item_desc pctxt
+  (* File Linting *)
+  | L : { source: string;
+          pattern: file
+        } -> file pctxt
 
+
+(*
+   Using an explicit definition wrapping for the phantom
+   type for in_channel.
+
+   For the reason why we have to do this, see
+github.com/ocaml/ocaml/issues/7360.
+   Essentially, if we wanted to make a just
+in_channel pctxt, the OCaml typechecker would have no idea how
+in_channel was defined. In theory, it could have been that
+type in_channel = Parsetree.expression_desc, which means that
+it is possible for more than one constructor to have produced
+a Parsetree.x ctxt. Therefore the exhaustiveness checker would trigger,
+forcing all cases to have been matched, since we don't have the invariant of
+one constructor per transparent type.
+
+The type parameter in_channel is hidden, so we have no clue how it's defined,
+and although it definitely doesn't alias the Parsetree, its hidden.
+Therefore, we have to produce an explicit wrapping for it.
+
+*)
+and file = F of in_channel
+             
 let ctxt_of_expr filename (expr: Parsetree.expression) : Parsetree.expression_desc pctxt =
   let loc = Warnloc.warn_loc_of_loc filename expr.pexp_loc in
   let raw = Pprintast.string_of_expression expr in
@@ -21,3 +62,5 @@ let ctxt_of_structure source (structure: Parsetree.structure_item) : Parsetree.s
   let raw = Pprintast.string_of_structure [structure] in
   P {location = loc; source = raw; pattern = structure.pstr_desc}
 
+let ctxt_for_lexical source channel : file pctxt =
+  L {source; pattern = F channel}

--- a/lib/canonical/warnloc.ml
+++ b/lib/canonical/warnloc.ml
@@ -24,3 +24,5 @@ let warn_loc_of_loc f (l: Location.t) : warn_loc =
     fin.pos_lnum
     (start.pos_cnum - start.pos_bol)
     (fin.pos_cnum - fin.pos_bol)
+
+let no_loc f = {file = f; line_start = 0; line_end = 0; col_start = 0; col_end = 0}

--- a/lib/style/check.ml
+++ b/lib/style/check.ml
@@ -1,19 +1,30 @@
 open Canonical
-  
+
+(** The Check interface - fill this out with the kind of check you would like to make. *)
 module type CHECK = sig
+  
+  (** The internal CHECK type - represents the kind of context a checker will need *)
   type ctxt
-  (* The fix for this check *)
+
+  (** The fix for this check *)
   val fix : Hint.fix
-  (* The violation associated with this check *)
+              
+  (** The violation associated with this check *)
   val violation : Hint.violation
-  (* A method that performs a check, given a lint context, and adds the hint to the list*)
+                    
+  (** A method that performs a check, given a lint context, and adds the hint to the list*)
   val check : Hint.hint list ref -> ctxt -> unit
-  (* Exposes the name and checker method for convenience. *)
+    
+  (** Exposes the name and checker method for convenience. *)
   val name : string * (Hint.hint list ref -> ctxt -> unit)
+                      
 end
 
+(** Signature for expression checking rules *)
 module type EXPRCHECK = CHECK with type ctxt = Parsetree.expression_desc Pctxt.pctxt
 
+(** Signature for structure (top-level) checking rules *)
 module type STRUCTURECHECK = CHECK with type ctxt = Parsetree.structure_item_desc Pctxt.pctxt
-  
+
+(** Signature for lexical checking rules *)
 module type LEXICALCHECK = CHECK with type ctxt = Pctxt.file Pctxt.pctxt

--- a/lib/style/check.ml
+++ b/lib/style/check.ml
@@ -16,3 +16,4 @@ module type EXPRCHECK = CHECK with type ctxt = Parsetree.expression_desc Pctxt.p
 
 module type STRUCTURECHECK = CHECK with type ctxt = Parsetree.structure_item_desc Pctxt.pctxt
   
+module type LEXICALCHECK = CHECK with type ctxt = Pctxt.file Pctxt.pctxt

--- a/lib/style/checkers.ml
+++ b/lib/style/checkers.ml
@@ -1,3 +1,4 @@
+(** Expression checks *)
 let expr_checks = [
   Equality.EqList.name
 ; Equality.EqOption.name
@@ -21,12 +22,14 @@ let expr_checks = [
 ; Verbose.RedundantAnd.name
 ]
 
+(** Top-level structure checks *)
 let struct_checks = [
   Hof.UseMap.name
 ; Hof.UseFold.name
 ; Hof.UseIter.name
 ]
 
+(** Lexical checks *)
 let lexical_checks = [
   Lexical.LineLength.name
 ]

--- a/lib/style/checkers.ml
+++ b/lib/style/checkers.ml
@@ -26,3 +26,7 @@ let struct_checks = [
 ; Hof.UseFold.name
 ; Hof.UseIter.name
 ]
+
+let lexical_checks = [
+  Lexical.LineLength.name
+]

--- a/lib/style/equality.ml
+++ b/lib/style/equality.ml
@@ -4,7 +4,7 @@ open Astutils
 open Check
 
     
-(* ------------------ Checks rules: if (_ = [literals] | [literals] = _)  ----------------------- *)
+(** ------------------ Checks rules: if (_ = [literals] | [literals] = _)  ----------------------- *)
 module EqList : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a pattern match to check whether a list has a certain value"
@@ -24,8 +24,7 @@ module EqList : EXPRCHECK = struct
 end
 
 
-(* ------------------ Checks rules: _ = [Some _ | None] | [Some _ | None] = _ -------------  *)
-
+(** ------------------ Checks rules: _ = [Some _ | None] | [Some _ | None] = _ -------------  *)
 module EqOption : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a pattern match to check the presence of an option"

--- a/lib/style/hof.ml
+++ b/lib/style/hof.ml
@@ -2,7 +2,8 @@ open Canonical
 open Check
 open Utils
 open Astutils
-    
+
+(** -------------- Checks rules: If top-level let should use List.map -------------------- *)
 module UseMap : STRUCTURECHECK = struct
   type ctxt = Parsetree.structure_item_desc Pctxt.pctxt
 
@@ -32,6 +33,7 @@ module UseMap : STRUCTURECHECK = struct
 end
 
 
+(** -------------- Checks rules: If top-level let should use List.fold_right ------------- *)
 module UseFold : STRUCTURECHECK = struct
   type ctxt = Parsetree.structure_item_desc Pctxt.pctxt
 
@@ -60,6 +62,7 @@ module UseFold : STRUCTURECHECK = struct
   let name = "UseFold", check
 end
 
+(** -------------- Checks rules: If top-level let should use List.iter ------------------- *)
 module UseIter : STRUCTURECHECK = struct
   
   type ctxt = Parsetree.structure_item_desc Pctxt.pctxt

--- a/lib/style/lexical.ml
+++ b/lib/style/lexical.ml
@@ -1,24 +1,26 @@
 open Canonical
-open Utils.IOUtils
+(* open Utils.IOUtils *)
 open Check
 
 
-module LineLength : EXPRCHECK = struct
+module LineLength : LEXICALCHECK = struct
 
-  type ctxt = Parsetree.expression_desc Pctxt.pctxt 
+  type ctxt = Pctxt.file Pctxt.pctxt 
   let fix = "indenting to avoid exceeding the line limit"
   let violation = "exceeding the 80 character line limit. Only showing (1) such violation of this kind, although there may be others - fix this and re-run the linter to find them."
     
-  let max_line_length = 80
-  let seen_line_exceed : bool ref = ref false
       
-  let check st (E ctxt: ctxt) =
-    if (ctxt.location.col_start > max_line_length || ctxt.location.col_end > max_line_length)
-       && not (!seen_line_exceed)
-    then
-      let raw = code_at_loc ctxt.location ctxt.source in
-      st := Hint.mk_hint ctxt.location raw fix violation :: !st;
-      seen_line_exceed := true
-
+  let check st (L {source; pattern = Pctxt.F chan}: ctxt) =
+    let filestream : (int * string) Stream.t =
+      Stream.from
+        (fun line -> try (Some (line, input_line chan))
+          with End_of_file -> None
+        ) in
+    
+    Stream.iter (fun (line_no, line) ->
+        if String.length line > 80 then
+          st := Hint.line_hint source line_no line :: !st
+      ) filestream
+    
   let name = "LineLength", check
 end

--- a/lib/style/lexical.ml
+++ b/lib/style/lexical.ml
@@ -1,15 +1,15 @@
 open Canonical
-(* open Utils.IOUtils *)
 open Check
 
-
+(** --------- Checks rules: lines that exceed 80 characters in a given file ------------ *)
 module LineLength : LEXICALCHECK = struct
 
   type ctxt = Pctxt.file Pctxt.pctxt 
+
   let fix = "indenting to avoid exceeding the line limit"
+
   let violation = "exceeding the 80 character line limit. Only showing (1) such violation of this kind, although there may be others - fix this and re-run the linter to find them."
     
-      
   let check st (L {source; pattern = Pctxt.F chan}: ctxt) =
     let filestream : (int * string) Stream.t =
       Stream.from
@@ -23,4 +23,5 @@ module LineLength : LEXICALCHECK = struct
       ) filestream
     
   let name = "LineLength", check
+
 end

--- a/lib/style/match.ml
+++ b/lib/style/match.ml
@@ -57,7 +57,7 @@ module MatchInt : EXPRCHECK = struct
              
 end
 
-(** --------------------- Checks rules: match _ with | {f1;f2;...} ------------------------------ *)
+(** --------------------- Checks rules: match _ with | \{f1;f2;...\} ------------------------------ *)
 module MatchRecord : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a let statement to extract record fields"

--- a/lib/style/match.ml
+++ b/lib/style/match.ml
@@ -31,7 +31,7 @@ let make_check (pred: Parsetree.pattern -> bool) gen_error override_len enable_u
     | _ -> ()
     end
     
-
+(** --------------------- Checks rules: match _ with | true | false ----------------------------- *)
 module MatchBool : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using an if statement or boolean operators"
@@ -44,6 +44,7 @@ module MatchBool : EXPRCHECK = struct
   let name = "MatchBool", check
 end
 
+(** --------------------- Checks rules: match _ with | 0 | n ------------------------------------ *)
 module MatchInt : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using an if statement and `=`"
@@ -56,6 +57,7 @@ module MatchInt : EXPRCHECK = struct
              
 end
 
+(** --------------------- Checks rules: match _ with | {f1;f2;...} ------------------------------ *)
 module MatchRecord : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a let statement to extract record fields"
@@ -69,6 +71,7 @@ module MatchRecord : EXPRCHECK = struct
 end 
 
 
+(** --------------------- Checks rules: match _ with | (_, _ ..) -------------------------------- *)
 module MatchTuple : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a let statement to extract tuple fields"
@@ -82,6 +85,7 @@ module MatchTuple : EXPRCHECK = struct
 end
 
 
+(** --------------------- Checks rules: match _ with | x :: [] ---------------------------------- *)
 module MatchListVerbose : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "expressing this match case more compactly"

--- a/lib/style/verbose.ml
+++ b/lib/style/verbose.ml
@@ -3,7 +3,7 @@ open Utils
 open Astutils
 open Check
 
-
+(** ----------------------- Checks rules: [_] @ _ ---------------------------- *)
 module LitPrepend : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using `::` instead"
@@ -20,6 +20,7 @@ module LitPrepend : EXPRCHECK = struct
 end
 
 
+(** ----------------------- Checks rules: fst/snd t -------------------------- *)
 module TupleProj : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using a let pattern match statement instead"
@@ -34,6 +35,7 @@ module TupleProj : EXPRCHECK = struct
     let name = "TupleProj", check
 end
 
+(** ----------------------- Checks rules: Nesting if >= 3 levels ------------- *)
 module NestedIf : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using let statements or helper methods / rethinking logic"
@@ -53,6 +55,7 @@ module NestedIf : EXPRCHECK = struct
     let name = "NestedIf", check
 end
 
+(** -------------------- Checks rules: Nesting match >= 3 levels ------------- *)
 module NestedMatch : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using let statements or helper methods / rethinking logic"
@@ -81,7 +84,7 @@ module NestedMatch : EXPRCHECK = struct
     let name = "NestedMatch", check
 end
 
-
+(** ------------ Checks rules: if _ then/else true | false  ------------------ *)
 module IfReturnsLit : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "returning just the condition (+ some tweaks)"
@@ -97,7 +100,7 @@ module IfReturnsLit : EXPRCHECK = struct
     let name = "IfReturnsLit", check
 end
 
-
+(** ------------ Checks rules: if cond then cond | if cond then _ else cond -- *)
 module IfCondThenCond : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "returning just the condition or simplifying further"
@@ -113,6 +116,7 @@ module IfCondThenCond : EXPRCHECK = struct
 end
 
 
+(** ------------ Checks rules: if not cond then x else y --------------------- *)
 module IfNotCond : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "swapping the then and else branches of the if statement"
@@ -130,6 +134,7 @@ module IfNotCond : EXPRCHECK = struct
     let name = "IfNotCond", check
 end
 
+(** ------------ Checks rules: if x then true else y ------------------------- *)
 module IfToOr : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "rewriting using a boolean operator like `||`"
@@ -148,6 +153,7 @@ module IfToOr : EXPRCHECK = struct
   let name = "IfToOr", check
 end
 
+(** ------------ Checks rules: if x then y else false ------------------------ *)
 module IfToAnd : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "rewriting using a boolean operator like `&&`"
@@ -167,6 +173,7 @@ module IfToAnd : EXPRCHECK = struct
     let name = "IfToAnd", check
 end
 
+(** ------------ Checks rules: if x then false else y ------------------------ *)
 module IfToAndInv : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "rewriting using a boolean operator like `&&` and `not`"
@@ -181,6 +188,7 @@ module IfToAndInv : EXPRCHECK = struct
     let name = "IfToAndInv", check
 end
 
+(** ------------ Checks rules: if x then y else true ------------------------ *)
 module IfToOrInv : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "rewriting using a boolean operator like `||` and `not`"
@@ -195,6 +203,7 @@ module IfToOrInv : EXPRCHECK = struct
     let name = "IfToOrInv", check
 end
 
+(** ------------ Checks rules: ... || true | true || ... | false || ... | ... || false -- *)
 module RedundantOr : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "simplifying further"
@@ -213,6 +222,7 @@ module RedundantOr : EXPRCHECK = struct
     let name = "RedundantOr", check
 end
 
+(** ------------ Checks rules: ... && true | true && ... | false && ... | ... && false -- *)
 module RedundantAnd : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "simplifying further"

--- a/lib/style/verbose.ml
+++ b/lib/style/verbose.ml
@@ -3,7 +3,7 @@ open Utils
 open Astutils
 open Check
 
-(** ----------------------- Checks rules: [_] @ _ ---------------------------- *)
+(** ----------------------- Checks rules: [_] \@ _ ---------------------------- *)
 module LitPrepend : EXPRCHECK = struct
   type ctxt = Parsetree.expression_desc Pctxt.pctxt
   let fix = "using `::` instead"

--- a/lib/traverse/descent.ml
+++ b/lib/traverse/descent.ml
@@ -443,3 +443,8 @@ module CE = struct
     sub.location sub pci_loc;
     sub.attributes sub pci_attributes
 end
+
+module ST = struct
+  let iter sub =
+    List.iter (sub.structure_item sub)
+end

--- a/lib/traverse/find.ml
+++ b/lib/traverse/find.ml
@@ -48,3 +48,8 @@ let pass_structures (store: Hint.hint list ref) (f: string) (structure : Parsetr
   List.iter (fun check -> check store pc) checks
 
   
+let pass_file (store: Hint.hint list ref) (f: string) (_payload: Parsetree.structure) : unit =
+  let pc = Pctxt.ctxt_for_lexical f (open_in f) in
+  let checks =
+    Style.Checkers.lexical_checks |> Arthur.extract (Lazy.force cfg) in
+  List.iter (fun (_, check) -> check store pc) checks

--- a/lib/traverse/iterator.ml
+++ b/lib/traverse/iterator.ml
@@ -12,11 +12,12 @@ let apply_iterator (structure: Parsetree.structure) (iter: Ast_iterator.iterator
    Defines a linter iterator for traversing the OCaml AST.
    You can write your own Custom expression handler 
 *)
-let rec linterator exp_handler structitem_handler = 
+let rec linterator exp_handler structitem_handler structure_handler = 
   {
     default_iterator with
     expr = expr_iterator exp_handler;
-    structure_item = structure_item_iterator structitem_handler
+    structure_item = structure_item_iterator structitem_handler;
+    structure = structure_iterator structure_handler
     
   }
 
@@ -30,10 +31,13 @@ and structure_item_iterator (handler: Parsetree.structure_item -> 'a) (iterator:
   handler structure_item;
   M.iter_structure_item iterator structure_item
 
-
+and structure_iterator (handler: Parsetree.structure -> 'a) (iterator: Ast_iterator.iterator)
+    (payload: Parsetree.structure) : unit =
+  handler payload;
+  ST.iter iterator payload
 
 (** Given a list ref and a filename, produce an iterator that runs the pass_checks method at each expression node in the
     OCaml ast. This will mutate the store by appending new hints the checkers find as they analyse the source code.
 *)
 let make_linterator = fun store fname -> 
-  linterator (pass_exprs store fname) (pass_structures store fname)
+  linterator (pass_exprs store fname) (pass_structures store fname) (pass_file store fname)

--- a/lib/utils/ioutils.ml
+++ b/lib/utils/ioutils.ml
@@ -1,5 +1,7 @@
 open Canonical
 
+
+
 let read_at_loc (loc: Warn.warn_loc) =
   (* Produce a line-by-line stream from a file *)
   

--- a/test/test.ml
+++ b/test/test.ml
@@ -46,6 +46,24 @@ let%expect_test _ =
   line_lint := false;
   [%expect{|
     (* ------------------------------------------------------------------------ *)
+    File ./examples/lexical.ml, line 4, columns: 0-80
+    Warning:
+    	exceeding the 80 character line limit
+    You wrote:
+    	 let verylongvariablenamethisispainful = [1;2;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1]
+    Consider:
+    	indenting to avoid exceeding the 80 character line limit
+
+    (* ------------------------------------------------------------------------ *)
+    File ./examples/lexical.ml, line 1, columns: 0-80
+    Warning:
+    	exceeding the 80 character line limit
+    You wrote:
+    	 let verylongvariablenamethisispainful = [1;2;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1]
+    Consider:
+    	indenting to avoid exceeding the 80 character line limit
+
+    (* ------------------------------------------------------------------------ *)
     File ./examples/lexical.ml, line 5, columns: 0-80
     Warning:
     	exceeding the 80 character line limit
@@ -170,6 +188,24 @@ let%expect_test _ =
     	 [1] @ t
     Consider:
     	using `::` instead
+
+    (* ------------------------------------------------------------------------ *)
+    File ./examples/verbose.ml, line 49, columns: 0-80
+    Warning:
+    	exceeding the 80 character line limit
+    You wrote:
+    	 let z = if x then 1 else if y then 2 else if x & y then 3 else if z = 4 then 3 else 9
+    Consider:
+    	indenting to avoid exceeding the 80 character line limit
+
+    (* ------------------------------------------------------------------------ *)
+    File ./examples/verbose.ml, line 12, columns: 0-80
+    Warning:
+    	exceeding the 80 character line limit
+    You wrote:
+    	 (* Nested ifs :( - we skip local lets and sequencing to get the actual return type for now *)
+    Consider:
+    	indenting to avoid exceeding the 80 character line limit
   |}]
   
 (* Run the tests in if.ml *)


### PR DESCRIPTION
This pr:
* Cleans up arthur to use the new monadic-let binding syntax.
* Adds documentation for the CHECK interface, and it's derived sub interfaces. 
* Adds comments for the various checkers indicating what rules they check for.
* Adds comments the arthur_parse folder.
* Refactors the line-length testing (that we moved out to linter.ml temporarily for HW2) back into the CHECK interface, so that we can start ignoring these rules (but only at a global level).

^^ The above comments are docstring comments, meaning they are inserted into the docs that dune can generate.