### PR TITLE
Fix the version constraint on ppx_expect

### DIFF
--- a/camelot.opam
+++ b/camelot.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "ANSITerminal" {>= "0.8"}
   "yojson" {>= "1.7.0"}
-  "ppx_expect" {with-test & >= "0.13.0"}
+  "ppx_expect" {with-test & >= "v0.13.0"}
   "odoc" {with-doc & >= "1.5.0"}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
   (ocaml (>= 4.10.0))
   (ANSITerminal (>= 0.8))
   (yojson (>= 1.7.0))
-  (ppx_expect (and :with-test (>= 0.13.0)))
+  (ppx_expect (and :with-test (>= v0.13.0)))
   (odoc (and :with-doc (>= 1.5.0)))
  )
 )


### PR DESCRIPTION
My fix to `camelot.1.4.2` in opam-repository (https://github.com/ocaml/opam-repository/pull/16595#issuecomment-641613216) wasn't upstreamed.

I also have a question: given camelot currently seems to compile with OCaml 4.11, would it be ok to relax the constraint in opam-repository for its last version, or does it need some extra work for it to be compatible with OCaml 4.11?