### PR TITLE
Feature: print as json

### DIFF
--- a/bin/camelot.ml
+++ b/bin/camelot.ml
@@ -18,6 +18,7 @@ let set_display_type : string -> unit = fun s ->
   match s with
   | "ta" -> show_type := Display.ta_display
   | "gradescope" -> show_type := Display.gradescope_display
+  | "json" -> show_type := Display.json_display
   | _ -> show_type := Display.student_display
 
 let set_config_file : string -> unit = fun s ->

--- a/lib/report/display.ml
+++ b/lib/report/display.ml
@@ -12,6 +12,16 @@ let string_of_warnloc : Warn.warn_loc -> string =
     "columns: " ^ (string_of_int col_start) ^ "-" ^ (string_of_int col_end)
   )    
 
+let json_of_hint : Hint.hint -> Yojson.Basic.t =
+  fun {loc; raw; fix; violation} ->
+  `Assoc [
+    ("filename", `String loc.file);
+    ("line", `List [`Int loc.line_start; `Int loc.line_end]);
+    ("col", `List [`Int loc.col_start; `Int loc.col_end]);
+    ("source", `String raw);
+    ("fix", `String fix);
+    ("violation", `String violation)
+  ]
 
 (* Utility display methods *)
 (* TODO: in the mli file, don't expose these methods  *)
@@ -59,3 +69,6 @@ let gradescope_display : Hint.hint list -> unit = fun l ->
   let score = string_of_int (Grade.simple l) in
   print_string score
 
+
+let json_display : Hint.hint list -> unit = fun l ->
+  print_string (Yojson.Basic.to_string (`List (List.map json_of_hint l)))

--- a/lib/report/dune
+++ b/lib/report/dune
@@ -1,3 +1,3 @@
 (library
  (name report)
- (libraries compiler-libs.common ANSITerminal canonical))
+ (libraries compiler-libs.common ANSITerminal canonical yojson))


### PR DESCRIPTION
This pull request resolves #66 (I know, I opened the issue and I ended up resolving it 😅)

I've added `yojson` to lib/report/dune so that the utility function `json_of_hint` and the new display function `json_display` under lib/report/display.ml can access the Yojson library.

I've also modified the flag matching in bin/camelot.ml to include "json" in the "-show" option so that `Display.json_display` can be called accordingly.

Let me know if other edits should be made!