### PR TITLE
Fix fd leak; print more info when failing

### DIFF
--- a/lib/traverse/find.ml
+++ b/lib/traverse/find.ml
@@ -49,7 +49,9 @@ let pass_structures (store: Hint.hint list ref) (f: string) (structure : Parsetr
 
 
 let pass_file (store: Hint.hint list ref) (f: string) (_payload: Parsetree.structure) : unit =
-  let pc = Pctxt.ctxt_for_lexical f (open_in f) in
+  let ch = open_in f in
+  let pc = Pctxt.ctxt_for_lexical f ch in
   let checks =
     Style.Checkers.lexical_checks |> Arthur.extract (Lazy.force cfg) in
-  List.iter (fun (_, check) -> check store pc) checks
+  List.iter (fun (_, check) -> check store pc) checks;
+  close_in ch


### PR DESCRIPTION
- Close file descriptors once the file has been parsed
- remove lexing function, as it does not actually parse the file
- add some information in case of failure